### PR TITLE
feat: JWT認証基盤・API共通基盤の実装 (#4)

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -12,9 +12,11 @@
         "@prisma/client": "^7.4.2",
         "bcryptjs": "^3.0.3",
         "better-sqlite3": "^12.6.2",
+        "jose": "^6.0.11",
         "next": "16.1.6",
         "react": "19.2.3",
-        "react-dom": "19.2.3"
+        "react-dom": "19.2.3",
+        "zod": "^4.3.6"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4",
@@ -23,6 +25,7 @@
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
+        "@vitest/coverage-v8": "^3.2.4",
         "dotenv": "^17.3.1",
         "eslint": "^9",
         "eslint-config-next": "16.1.6",
@@ -34,7 +37,8 @@
         "prisma": "^7.4.2",
         "tailwindcss": "^4",
         "tsx": "^4.21.0",
-        "typescript": "^5"
+        "typescript": "^5",
+        "vitest": "^3.2.4"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -48,6 +52,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@ampproject/remapping": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -289,6 +307,16 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@chevrotain/cst-dts-gen": {
@@ -1509,6 +1537,83 @@
         "url": "https://opencollective.com/libvips"
       }
     },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
+      "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -1778,6 +1883,17 @@
         "node": ">=12.4.0"
       }
     },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/@prisma/adapter-better-sqlite3": {
       "version": "7.4.2",
       "resolved": "https://registry.npmjs.org/@prisma/adapter-better-sqlite3/-/adapter-better-sqlite3-7.4.2.tgz",
@@ -1960,6 +2076,356 @@
         "react": "^18.0.0 || ^19.0.0",
         "react-dom": "^18.0.0 || ^19.0.0"
       }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.59.0.tgz",
+      "integrity": "sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.59.0.tgz",
+      "integrity": "sha512-hZ+Zxj3SySm4A/DylsDKZAeVg0mvi++0PYVceVyX7hemkw7OreKdCvW2oQ3T1FMZvCaQXqOTHb8qmBShoqk69Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.59.0.tgz",
+      "integrity": "sha512-W2Psnbh1J8ZJw0xKAd8zdNgF9HRLkdWwwdWqubSVk0pUuQkoHnv7rx4GiF9rT4t5DIZGAsConRE3AxCdJ4m8rg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.59.0.tgz",
+      "integrity": "sha512-ZW2KkwlS4lwTv7ZVsYDiARfFCnSGhzYPdiOU4IM2fDbL+QGlyAbjgSFuqNRbSthybLbIJ915UtZBtmuLrQAT/w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.59.0.tgz",
+      "integrity": "sha512-EsKaJ5ytAu9jI3lonzn3BgG8iRBjV4LxZexygcQbpiU0wU0ATxhNVEpXKfUa0pS05gTcSDMKpn3Sx+QB9RlTTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.59.0.tgz",
+      "integrity": "sha512-d3DuZi2KzTMjImrxoHIAODUZYoUUMsuUiY4SRRcJy6NJoZ6iIqWnJu9IScV9jXysyGMVuW+KNzZvBLOcpdl3Vg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.59.0.tgz",
+      "integrity": "sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.59.0.tgz",
+      "integrity": "sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.59.0.tgz",
+      "integrity": "sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.59.0.tgz",
+      "integrity": "sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.59.0.tgz",
+      "integrity": "sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.59.0.tgz",
+      "integrity": "sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.59.0.tgz",
+      "integrity": "sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.59.0.tgz",
+      "integrity": "sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.59.0.tgz",
+      "integrity": "sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.59.0.tgz",
+      "integrity": "sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.59.0.tgz",
+      "integrity": "sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.59.0.tgz",
+      "integrity": "sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.59.0.tgz",
+      "integrity": "sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.59.0.tgz",
+      "integrity": "sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.59.0.tgz",
+      "integrity": "sha512-tt9KBJqaqp5i5HUZzoafHZX8b5Q2Fe7UjYERADll83O4fGqJ49O1FsL6LpdzVFQcpwvnyd0i+K/VSwu/o/nWlA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.59.0.tgz",
+      "integrity": "sha512-V5B6mG7OrGTwnxaNUzZTDTjDS7F75PO1ae6MJYdiMu60sq0CqN5CVeVsbhPxalupvTX8gXVSU9gq+Rx1/hvu6A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.59.0.tgz",
+      "integrity": "sha512-UKFMHPuM9R0iBegwzKF4y0C4J9u8C6MEJgFuXTBerMk7EJ92GFVFYBfOZaSGLu6COf7FxpQNqhNS4c4icUPqxA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.59.0.tgz",
+      "integrity": "sha512-laBkYlSS1n2L8fSo1thDNGrCTQMmxjYY5G0WFWjFFYZkKPjsMBsgJfGf4TLxXrF6RyhI60L8TMOjBMvXiTcxeA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.59.0.tgz",
+      "integrity": "sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
@@ -2282,6 +2748,24 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -2900,6 +3384,155 @@
         "win32"
       ]
     },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-3.2.4.tgz",
+      "integrity": "sha512-EyF9SXU6kS5Ku/U82E259WSnvg6c8KTjppUncuNdm5QHpe17mwREHnjDzozC8x9MZ0xfBUFSaLkRv4TMA75ALQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ampproject/remapping": "^2.3.0",
+        "@bcoe/v8-coverage": "^1.0.2",
+        "ast-v8-to-istanbul": "^0.3.3",
+        "debug": "^4.4.1",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-lib-source-maps": "^5.0.6",
+        "istanbul-reports": "^3.1.7",
+        "magic-string": "^0.30.17",
+        "magicast": "^0.3.5",
+        "std-env": "^3.9.0",
+        "test-exclude": "^7.0.1",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "3.2.4",
+        "vitest": "3.2.4"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
+      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
+      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
+      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
+      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.4",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
+      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
+      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
+      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -3163,10 +3796,39 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/ast-types-flow": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.8.tgz",
       "integrity": "sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "0.3.12",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-0.3.12.tgz",
+      "integrity": "sha512-BRRC8VRZY2R4Z4lFIL35MwNXmwVqBityvOIwETtsCSwvjl0IdgFsy9NhdaA6j74nUdtJJlIypeRhpDam19Wq3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
       "dev": true,
       "license": "MIT"
     },
@@ -3433,6 +4095,16 @@
         "url": "https://dotenvx.com"
       }
     },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/call-bind": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
@@ -3513,6 +4185,23 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -3528,6 +4217,16 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/chevrotain": {
@@ -3800,6 +4499,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/deep-extend": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
@@ -3935,6 +4644,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/effect": {
       "version": "3.18.4",
@@ -4123,6 +4839,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
@@ -4687,6 +5410,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -4711,6 +5444,16 @@
       "license": "(MIT OR WTFPL)",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/exsolve": {
@@ -5113,6 +5856,28 @@
       "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
       "license": "MIT"
     },
+    "node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/glob-parent": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -5124,6 +5889,32 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/globals": {
@@ -5311,6 +6102,13 @@
       "engines": {
         "node": ">=16.9.0"
       }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/http-status-codes": {
       "version": "2.3.0",
@@ -5888,6 +6686,60 @@
       "devOptional": true,
       "license": "ISC"
     },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
+      "integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.23",
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/iterator.prototype": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/iterator.prototype/-/iterator.prototype-1.1.5.tgz",
@@ -5906,6 +6758,22 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
     "node_modules/jiti": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
@@ -5914,6 +6782,15 @@
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/jose": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.1.3.tgz",
+      "integrity": "sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/js-tokens": {
@@ -6456,6 +7333,13 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -6490,6 +7374,48 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz",
+      "integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/parser": "^7.25.4",
+        "@babel/types": "^7.25.4",
+        "source-map-js": "^1.2.0"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/make-dir/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/math-intrinsics": {
@@ -6571,6 +7497,16 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/mkdirp-classic": {
@@ -7053,6 +7989,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -7093,12 +8036,46 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-scurry/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/pathe": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
     },
     "node_modules/perfect-debounce": {
       "version": "1.0.0",
@@ -7688,6 +8665,51 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/rollup": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.0.tgz",
+      "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.59.0",
+        "@rollup/rollup-android-arm64": "4.59.0",
+        "@rollup/rollup-darwin-arm64": "4.59.0",
+        "@rollup/rollup-darwin-x64": "4.59.0",
+        "@rollup/rollup-freebsd-arm64": "4.59.0",
+        "@rollup/rollup-freebsd-x64": "4.59.0",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.59.0",
+        "@rollup/rollup-linux-arm-musleabihf": "4.59.0",
+        "@rollup/rollup-linux-arm64-gnu": "4.59.0",
+        "@rollup/rollup-linux-arm64-musl": "4.59.0",
+        "@rollup/rollup-linux-loong64-gnu": "4.59.0",
+        "@rollup/rollup-linux-loong64-musl": "4.59.0",
+        "@rollup/rollup-linux-ppc64-gnu": "4.59.0",
+        "@rollup/rollup-linux-ppc64-musl": "4.59.0",
+        "@rollup/rollup-linux-riscv64-gnu": "4.59.0",
+        "@rollup/rollup-linux-riscv64-musl": "4.59.0",
+        "@rollup/rollup-linux-s390x-gnu": "4.59.0",
+        "@rollup/rollup-linux-x64-gnu": "4.59.0",
+        "@rollup/rollup-linux-x64-musl": "4.59.0",
+        "@rollup/rollup-openbsd-x64": "4.59.0",
+        "@rollup/rollup-openharmony-arm64": "4.59.0",
+        "@rollup/rollup-win32-arm64-msvc": "4.59.0",
+        "@rollup/rollup-win32-ia32-msvc": "4.59.0",
+        "@rollup/rollup-win32-x64-gnu": "4.59.0",
+        "@rollup/rollup-win32-x64-msvc": "4.59.0",
+        "fsevents": "~2.3.2"
+      }
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -8022,6 +9044,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -8136,6 +9165,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/std-env": {
       "version": "3.10.0",
       "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
@@ -8191,6 +9227,62 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string-width-cjs/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/string.prototype.includes": {
@@ -8322,6 +9414,30 @@
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/strip-bom": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
@@ -8344,6 +9460,26 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/strip-literal/node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/styled-jsx": {
       "version": "5.1.6",
@@ -8443,6 +9579,67 @@
         "node": ">=6"
       }
     },
+    "node_modules/test-exclude": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.2.tgz",
+      "integrity": "sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^10.4.1",
+        "minimatch": "^10.2.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/test-exclude/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/test-exclude/node_modules/brace-expansion": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
+      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/test-exclude/node_modules/minimatch": {
+      "version": "10.2.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
+      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyexec": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
@@ -8500,6 +9697,36 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/to-regex-range": {
@@ -8566,6 +9793,7 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -8845,6 +10073,229 @@
         }
       }
     },
+    "node_modules/vite": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
+      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
+      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.4",
+        "@vitest/mocker": "3.2.4",
+        "@vitest/pretty-format": "^3.2.4",
+        "@vitest/runner": "3.2.4",
+        "@vitest/snapshot": "3.2.4",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.4",
+        "@vitest/ui": "3.2.4",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/vitest/node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -8950,6 +10401,23 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -8976,6 +10444,80 @@
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/wrap-ansi/node_modules/ansi-styles": {
@@ -9073,7 +10615,6 @@
       "version": "4.3.6",
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
-      "dev": true,
       "license": "MIT",
       "peer": true,
       "funding": {

--- a/app/package.json
+++ b/app/package.json
@@ -14,7 +14,10 @@
     "db:migrate": "prisma migrate dev",
     "db:seed": "prisma db seed",
     "db:reset": "prisma migrate reset",
-    "db:studio": "prisma studio"
+    "db:studio": "prisma studio",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage"
   },
   "prisma": {
     "seed": "tsx prisma/seed.ts"
@@ -24,9 +27,11 @@
     "@prisma/client": "^7.4.2",
     "bcryptjs": "^3.0.3",
     "better-sqlite3": "^12.6.2",
+    "jose": "^6.0.11",
     "next": "16.1.6",
     "react": "19.2.3",
-    "react-dom": "19.2.3"
+    "react-dom": "19.2.3",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",
@@ -46,7 +51,9 @@
     "prisma": "^7.4.2",
     "tailwindcss": "^4",
     "tsx": "^4.21.0",
-    "typescript": "^5"
+    "typescript": "^5",
+    "vitest": "^3.2.4",
+    "@vitest/coverage-v8": "^3.2.4"
   },
   "lint-staged": {
     "src/**/*.{ts,tsx}": [

--- a/app/src/lib/api/__tests__/errors.test.ts
+++ b/app/src/lib/api/__tests__/errors.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  AppError,
+  ErrorCode,
+  getHttpStatusForErrorCode,
+  type ValidationErrorDetail,
+} from '../errors';
+
+describe('errors', () => {
+  describe('ErrorCode', () => {
+    it('全てのエラーコードが定義されている', () => {
+      expect(ErrorCode.AUTHENTICATION_FAILED).toBe('AUTHENTICATION_FAILED');
+      expect(ErrorCode.TOKEN_EXPIRED).toBe('TOKEN_EXPIRED');
+      expect(ErrorCode.TOKEN_INVALID).toBe('TOKEN_INVALID');
+      expect(ErrorCode.FORBIDDEN).toBe('FORBIDDEN');
+      expect(ErrorCode.NOT_FOUND).toBe('NOT_FOUND');
+      expect(ErrorCode.DUPLICATE_REPORT).toBe('DUPLICATE_REPORT');
+      expect(ErrorCode.DUPLICATE_EMAIL).toBe('DUPLICATE_EMAIL');
+      expect(ErrorCode.VALIDATION_ERROR).toBe('VALIDATION_ERROR');
+      expect(ErrorCode.CANNOT_DELETE_SUBMITTED).toBe('CANNOT_DELETE_SUBMITTED');
+      expect(ErrorCode.HAS_RELATED_RECORDS).toBe('HAS_RELATED_RECORDS');
+      expect(ErrorCode.INTERNAL_ERROR).toBe('INTERNAL_ERROR');
+    });
+  });
+
+  describe('AppError', () => {
+    it('正しいプロパティで初期化される', () => {
+      const error = new AppError(ErrorCode.NOT_FOUND, 'リソースが見つかりません');
+      expect(error.code).toBe('NOT_FOUND');
+      expect(error.message).toBe('リソースが見つかりません');
+      expect(error.statusCode).toBe(404);
+      expect(error.name).toBe('AppError');
+      expect(error.details).toBeUndefined();
+    });
+
+    it('バリデーション詳細を含めて初期化できる', () => {
+      const details: ValidationErrorDetail[] = [
+        { field: 'email', message: 'メールアドレスの形式が不正です' },
+        { field: 'name', message: '名前は必須です' },
+      ];
+      const error = new AppError(ErrorCode.VALIDATION_ERROR, '入力内容に誤りがあります', details);
+      expect(error.code).toBe('VALIDATION_ERROR');
+      expect(error.statusCode).toBe(422);
+      expect(error.details).toHaveLength(2);
+      expect(error.details![0].field).toBe('email');
+    });
+
+    it('Error クラスを継承している', () => {
+      const error = new AppError(ErrorCode.INTERNAL_ERROR, 'エラー');
+      expect(error).toBeInstanceOf(Error);
+      expect(error).toBeInstanceOf(AppError);
+    });
+
+    it('try-catch で捕捉できる', () => {
+      try {
+        throw new AppError(ErrorCode.FORBIDDEN, '権限がありません');
+      } catch (error) {
+        expect(error).toBeInstanceOf(AppError);
+        if (error instanceof AppError) {
+          expect(error.code).toBe('FORBIDDEN');
+          expect(error.statusCode).toBe(403);
+        }
+      }
+    });
+  });
+
+  describe('getHttpStatusForErrorCode', () => {
+    it.each([
+      { code: ErrorCode.AUTHENTICATION_FAILED, expected: 401 },
+      { code: ErrorCode.TOKEN_EXPIRED, expected: 401 },
+      { code: ErrorCode.TOKEN_INVALID, expected: 401 },
+      { code: ErrorCode.FORBIDDEN, expected: 403 },
+      { code: ErrorCode.NOT_FOUND, expected: 404 },
+      { code: ErrorCode.DUPLICATE_REPORT, expected: 409 },
+      { code: ErrorCode.DUPLICATE_EMAIL, expected: 409 },
+      { code: ErrorCode.VALIDATION_ERROR, expected: 422 },
+      { code: ErrorCode.CANNOT_DELETE_SUBMITTED, expected: 422 },
+      { code: ErrorCode.HAS_RELATED_RECORDS, expected: 422 },
+      { code: ErrorCode.INTERNAL_ERROR, expected: 500 },
+    ])('$code => $expected', ({ code, expected }) => {
+      expect(getHttpStatusForErrorCode(code)).toBe(expected);
+    });
+  });
+});

--- a/app/src/lib/api/__tests__/response.test.ts
+++ b/app/src/lib/api/__tests__/response.test.ts
@@ -1,0 +1,187 @@
+import { describe, expect, it } from 'vitest';
+
+import { AppError, ErrorCode } from '../errors';
+import {
+  buildPaginationInfo,
+  createErrorResponse,
+  createPaginatedResponse,
+  createSuccessResponse,
+  parsePaginationParams,
+} from '../response';
+
+describe('response', () => {
+  describe('createSuccessResponse', () => {
+    it('ステータス 200 の成功レスポンスを返す', async () => {
+      const data = { id: 1, name: 'テスト' };
+      const response = createSuccessResponse(data);
+      expect(response.status).toBe(200);
+      const body = await response.json();
+      expect(body.status).toBe('success');
+      expect(body.data).toEqual(data);
+    });
+
+    it('カスタムステータスコードを指定できる', async () => {
+      const response = createSuccessResponse({ id: 1 }, 201);
+      expect(response.status).toBe(201);
+      const body = await response.json();
+      expect(body.status).toBe('success');
+    });
+
+    it('配列データを返せる', async () => {
+      const data = [{ id: 1 }, { id: 2 }];
+      const response = createSuccessResponse(data);
+      const body = await response.json();
+      expect(body.data).toEqual(data);
+      expect(body.data).toHaveLength(2);
+    });
+
+    it('文字列データを返せる', async () => {
+      const response = createSuccessResponse('メッセージ');
+      const body = await response.json();
+      expect(body.data).toBe('メッセージ');
+    });
+  });
+
+  describe('createPaginatedResponse', () => {
+    it('ページネーション情報付きレスポンスを返す', async () => {
+      const data = [{ id: 1 }, { id: 2 }];
+      const pagination = {
+        current_page: 1,
+        per_page: 20,
+        total_count: 50,
+        total_pages: 3,
+      };
+      const response = createPaginatedResponse(data, pagination);
+      expect(response.status).toBe(200);
+      const body = await response.json();
+      expect(body.status).toBe('success');
+      expect(body.data).toEqual(data);
+      expect(body.pagination).toEqual(pagination);
+    });
+
+    it('空配列のページネーションレスポンスを返せる', async () => {
+      const pagination = {
+        current_page: 1,
+        per_page: 20,
+        total_count: 0,
+        total_pages: 0,
+      };
+      const response = createPaginatedResponse([], pagination);
+      const body = await response.json();
+      expect(body.data).toEqual([]);
+      expect(body.pagination.total_count).toBe(0);
+    });
+  });
+
+  describe('createErrorResponse', () => {
+    it('エラーレスポンスの形式が正しい', async () => {
+      const error = new AppError(ErrorCode.NOT_FOUND, 'リソースが見つかりません');
+      const response = createErrorResponse(error);
+      expect(response.status).toBe(404);
+      const body = await response.json();
+      expect(body.status).toBe('error');
+      expect(body.error.code).toBe('NOT_FOUND');
+      expect(body.error.message).toBe('リソースが見つかりません');
+      expect(body.error.details).toBeUndefined();
+    });
+
+    it('バリデーションエラーの詳細を含められる', async () => {
+      const error = new AppError(ErrorCode.VALIDATION_ERROR, '入力内容に誤りがあります', [
+        { field: 'email', message: '必須です' },
+      ]);
+      const response = createErrorResponse(error);
+      expect(response.status).toBe(422);
+      const body = await response.json();
+      expect(body.error.details).toHaveLength(1);
+      expect(body.error.details[0].field).toBe('email');
+    });
+
+    it('空の details 配列は含めない', async () => {
+      const error = new AppError(ErrorCode.VALIDATION_ERROR, 'エラー', []);
+      const response = createErrorResponse(error);
+      const body = await response.json();
+      expect(body.error.details).toBeUndefined();
+    });
+
+    it.each([
+      { code: ErrorCode.AUTHENTICATION_FAILED, expectedStatus: 401 },
+      { code: ErrorCode.TOKEN_INVALID, expectedStatus: 401 },
+      { code: ErrorCode.FORBIDDEN, expectedStatus: 403 },
+      { code: ErrorCode.NOT_FOUND, expectedStatus: 404 },
+      { code: ErrorCode.DUPLICATE_REPORT, expectedStatus: 409 },
+      { code: ErrorCode.INTERNAL_ERROR, expectedStatus: 500 },
+    ])('$code で HTTP $expectedStatus を返す', async ({ code, expectedStatus }) => {
+      const error = new AppError(code, 'テストメッセージ');
+      const response = createErrorResponse(error);
+      expect(response.status).toBe(expectedStatus);
+    });
+  });
+
+  describe('parsePaginationParams', () => {
+    it('デフォルト値（page=1, per_page=20）を返す', () => {
+      const params = new URLSearchParams();
+      const result = parsePaginationParams(params);
+      expect(result.page).toBe(1);
+      expect(result.perPage).toBe(20);
+      expect(result.skip).toBe(0);
+    });
+
+    it('指定されたページとページサイズを使用する', () => {
+      const params = new URLSearchParams({ page: '3', per_page: '10' });
+      const result = parsePaginationParams(params);
+      expect(result.page).toBe(3);
+      expect(result.perPage).toBe(10);
+      expect(result.skip).toBe(20);
+    });
+
+    it('page が 0 以下の場合は 1 に補正する', () => {
+      const params = new URLSearchParams({ page: '0' });
+      const result = parsePaginationParams(params);
+      expect(result.page).toBe(1);
+    });
+
+    it('per_page が 100 を超える場合は 100 に補正する', () => {
+      const params = new URLSearchParams({ per_page: '200' });
+      const result = parsePaginationParams(params);
+      expect(result.perPage).toBe(100);
+    });
+
+    it('per_page が 0 以下の場合は 1 に補正する', () => {
+      const params = new URLSearchParams({ per_page: '-5' });
+      const result = parsePaginationParams(params);
+      expect(result.perPage).toBe(1);
+    });
+
+    it('page が NaN の場合はデフォルト値 1 を使用する', () => {
+      const params = new URLSearchParams({ page: 'abc' });
+      const result = parsePaginationParams(params);
+      expect(result.page).toBe(1);
+    });
+
+    it('per_page が NaN の場合はデフォルト値 20 を使用する', () => {
+      const params = new URLSearchParams({ per_page: 'xyz' });
+      const result = parsePaginationParams(params);
+      expect(result.perPage).toBe(20);
+    });
+  });
+
+  describe('buildPaginationInfo', () => {
+    it('ページネーション情報を正しく生成する', () => {
+      const info = buildPaginationInfo(2, 10, 45);
+      expect(info.current_page).toBe(2);
+      expect(info.per_page).toBe(10);
+      expect(info.total_count).toBe(45);
+      expect(info.total_pages).toBe(5);
+    });
+
+    it('total_count が 0 の場合 total_pages は 0 を返す', () => {
+      const info = buildPaginationInfo(1, 20, 0);
+      expect(info.total_pages).toBe(0);
+    });
+
+    it('端数がある場合は切り上げる', () => {
+      const info = buildPaginationInfo(1, 10, 11);
+      expect(info.total_pages).toBe(2);
+    });
+  });
+});

--- a/app/src/lib/api/errors.ts
+++ b/app/src/lib/api/errors.ts
@@ -1,0 +1,79 @@
+/**
+ * アプリケーションエラーコード
+ * API仕様書のエラーコード一覧に準拠
+ */
+export const ErrorCode = {
+  /** ログイン認証失敗 */
+  AUTHENTICATION_FAILED: 'AUTHENTICATION_FAILED',
+  /** トークン有効期限切れ */
+  TOKEN_EXPIRED: 'TOKEN_EXPIRED',
+  /** 不正なトークン */
+  TOKEN_INVALID: 'TOKEN_INVALID',
+  /** アクセス権限なし */
+  FORBIDDEN: 'FORBIDDEN',
+  /** 対象リソースが見つからない */
+  NOT_FOUND: 'NOT_FOUND',
+  /** 同一日の日報が既に存在 */
+  DUPLICATE_REPORT: 'DUPLICATE_REPORT',
+  /** メールアドレス重複 */
+  DUPLICATE_EMAIL: 'DUPLICATE_EMAIL',
+  /** 入力値バリデーションエラー */
+  VALIDATION_ERROR: 'VALIDATION_ERROR',
+  /** 提出済み日報の削除不可 */
+  CANNOT_DELETE_SUBMITTED: 'CANNOT_DELETE_SUBMITTED',
+  /** 関連データ存在のため削除不可 */
+  HAS_RELATED_RECORDS: 'HAS_RELATED_RECORDS',
+  /** サーバー内部エラー */
+  INTERNAL_ERROR: 'INTERNAL_ERROR',
+} as const;
+
+export type ErrorCodeType = (typeof ErrorCode)[keyof typeof ErrorCode];
+
+/**
+ * エラーコードとHTTPステータスコードのマッピング
+ */
+const ERROR_STATUS_MAP: Record<ErrorCodeType, number> = {
+  [ErrorCode.AUTHENTICATION_FAILED]: 401,
+  [ErrorCode.TOKEN_EXPIRED]: 401,
+  [ErrorCode.TOKEN_INVALID]: 401,
+  [ErrorCode.FORBIDDEN]: 403,
+  [ErrorCode.NOT_FOUND]: 404,
+  [ErrorCode.DUPLICATE_REPORT]: 409,
+  [ErrorCode.DUPLICATE_EMAIL]: 409,
+  [ErrorCode.VALIDATION_ERROR]: 422,
+  [ErrorCode.CANNOT_DELETE_SUBMITTED]: 422,
+  [ErrorCode.HAS_RELATED_RECORDS]: 422,
+  [ErrorCode.INTERNAL_ERROR]: 500,
+};
+
+/**
+ * バリデーションエラーの詳細情報
+ */
+export interface ValidationErrorDetail {
+  field: string;
+  message: string;
+}
+
+/**
+ * アプリケーション共通エラークラス
+ */
+export class AppError extends Error {
+  public readonly code: ErrorCodeType;
+  public readonly statusCode: number;
+  public readonly details?: ValidationErrorDetail[];
+
+  constructor(code: ErrorCodeType, message: string, details?: ValidationErrorDetail[]) {
+    super(message);
+    this.name = 'AppError';
+    this.code = code;
+    this.statusCode = ERROR_STATUS_MAP[code];
+    this.details = details;
+  }
+}
+
+/**
+ * エラーコードからHTTPステータスコードを取得する
+ */
+export function getHttpStatusForErrorCode(code: ErrorCodeType): number {
+  return ERROR_STATUS_MAP[code];
+}

--- a/app/src/lib/api/handler.ts
+++ b/app/src/lib/api/handler.ts
@@ -1,0 +1,137 @@
+import type { NextRequest, NextResponse } from 'next/server';
+import { ZodError, type ZodSchema } from 'zod';
+
+import { verifyToken, type JwtPayload } from '@/lib/auth/jwt';
+
+import { AppError, ErrorCode, type ValidationErrorDetail } from './errors';
+import { createErrorResponse } from './response';
+
+/**
+ * 認証済みリクエストの型定義
+ */
+export interface AuthenticatedRequest {
+  user: JwtPayload;
+}
+
+/**
+ * API Routeハンドラーのコンテキスト
+ */
+export interface HandlerContext {
+  params: Promise<Record<string, string>>;
+}
+
+/**
+ * API Routeハンドラーのオプション
+ */
+interface HandlerOptions {
+  /** 認証が必要かどうか（デフォルト: true） */
+  auth?: boolean;
+}
+
+/**
+ * 認証不要のハンドラー関数の型
+ */
+type PublicHandler = (req: NextRequest, ctx: HandlerContext) => Promise<NextResponse>;
+
+/**
+ * 認証必須のハンドラー関数の型
+ */
+type AuthenticatedHandler = (
+  req: NextRequest,
+  ctx: HandlerContext & AuthenticatedRequest,
+) => Promise<NextResponse>;
+
+/**
+ * Authorization ヘッダーからBearerトークンを抽出する
+ */
+function extractBearerToken(req: NextRequest): string | null {
+  const authHeader = req.headers.get('Authorization');
+  if (!authHeader || !authHeader.startsWith('Bearer ')) {
+    return null;
+  }
+  return authHeader.slice(7);
+}
+
+/**
+ * 共通API Routeハンドラーラッパー
+ *
+ * - try-catchによるエラーハンドリング
+ * - JWT認証チェック（オプション）
+ * - AppErrorの自動変換
+ * - 未処理エラーの500レスポンス化
+ */
+export function withHandler(
+  handler: AuthenticatedHandler,
+  options?: HandlerOptions,
+): (req: NextRequest, ctx: HandlerContext) => Promise<NextResponse>;
+export function withHandler(
+  handler: PublicHandler,
+  options: HandlerOptions & { auth: false },
+): (req: NextRequest, ctx: HandlerContext) => Promise<NextResponse>;
+export function withHandler(
+  handler: AuthenticatedHandler | PublicHandler,
+  options: HandlerOptions = {},
+): (req: NextRequest, ctx: HandlerContext) => Promise<NextResponse> {
+  const { auth = true } = options;
+
+  return async (req: NextRequest, ctx: HandlerContext): Promise<NextResponse> => {
+    try {
+      if (auth) {
+        const token = extractBearerToken(req);
+        if (!token) {
+          throw new AppError(ErrorCode.TOKEN_INVALID, '認証トークンが必要です');
+        }
+
+        const user = await verifyToken(token);
+        const authenticatedCtx = { ...ctx, user };
+        return await (handler as AuthenticatedHandler)(req, authenticatedCtx);
+      }
+
+      return await (handler as PublicHandler)(req, ctx);
+    } catch (error) {
+      if (error instanceof AppError) {
+        return createErrorResponse(error);
+      }
+
+      if (error instanceof ZodError) {
+        const details: ValidationErrorDetail[] = error.issues.map((issue) => ({
+          field: issue.path.join('.'),
+          message: issue.message,
+        }));
+        const validationError = new AppError(
+          ErrorCode.VALIDATION_ERROR,
+          '入力内容に誤りがあります',
+          details,
+        );
+        return createErrorResponse(validationError);
+      }
+
+      console.error('Unhandled API error:', error);
+      const internalError = new AppError(
+        ErrorCode.INTERNAL_ERROR,
+        'サーバー内部エラーが発生しました',
+      );
+      return createErrorResponse(internalError);
+    }
+  };
+}
+
+/**
+ * リクエストボディをパース・バリデーションする
+ */
+export async function parseBody<T>(req: NextRequest, schema: ZodSchema<T>): Promise<T> {
+  const body = await req.json();
+  return schema.parse(body);
+}
+
+/**
+ * クエリパラメータをパース・バリデーションする
+ */
+export function parseQuery<T>(req: NextRequest, schema: ZodSchema<T>): T {
+  const searchParams = req.nextUrl.searchParams;
+  const params: Record<string, string> = {};
+  searchParams.forEach((value, key) => {
+    params[key] = value;
+  });
+  return schema.parse(params);
+}

--- a/app/src/lib/api/response.ts
+++ b/app/src/lib/api/response.ts
@@ -1,0 +1,100 @@
+import { NextResponse } from 'next/server';
+
+import type { AppError, ValidationErrorDetail } from './errors';
+
+/**
+ * ページネーション情報の型定義
+ */
+export interface PaginationInfo {
+  current_page: number;
+  per_page: number;
+  total_count: number;
+  total_pages: number;
+}
+
+/**
+ * 成功レスポンスを生成する
+ */
+export function createSuccessResponse<T>(data: T, status: number = 200): NextResponse {
+  return NextResponse.json(
+    {
+      status: 'success',
+      data,
+    },
+    { status },
+  );
+}
+
+/**
+ * ページネーション付き一覧レスポンスを生成する
+ */
+export function createPaginatedResponse<T>(data: T[], pagination: PaginationInfo): NextResponse {
+  return NextResponse.json(
+    {
+      status: 'success',
+      data,
+      pagination,
+    },
+    { status: 200 },
+  );
+}
+
+/**
+ * エラーレスポンスを生成する
+ */
+export function createErrorResponse(error: AppError): NextResponse {
+  const body: {
+    status: string;
+    error: {
+      code: string;
+      message: string;
+      details?: ValidationErrorDetail[];
+    };
+  } = {
+    status: 'error',
+    error: {
+      code: error.code,
+      message: error.message,
+    },
+  };
+
+  if (error.details && error.details.length > 0) {
+    body.error.details = error.details;
+  }
+
+  return NextResponse.json(body, { status: error.statusCode });
+}
+
+/**
+ * ページネーションパラメータを算出する
+ */
+export function parsePaginationParams(searchParams: URLSearchParams): {
+  page: number;
+  perPage: number;
+  skip: number;
+} {
+  const rawPage = parseInt(searchParams.get('page') || '1', 10);
+  const rawPerPage = parseInt(searchParams.get('per_page') || '20', 10);
+
+  const page = Math.max(1, Number.isNaN(rawPage) ? 1 : rawPage);
+  const perPage = Math.min(100, Math.max(1, Number.isNaN(rawPerPage) ? 20 : rawPerPage));
+  const skip = (page - 1) * perPage;
+
+  return { page, perPage, skip };
+}
+
+/**
+ * ページネーション情報を生成する
+ */
+export function buildPaginationInfo(
+  page: number,
+  perPage: number,
+  totalCount: number,
+): PaginationInfo {
+  return {
+    current_page: page,
+    per_page: perPage,
+    total_count: totalCount,
+    total_pages: Math.ceil(totalCount / perPage),
+  };
+}

--- a/app/src/lib/auth/__tests__/authorization.test.ts
+++ b/app/src/lib/auth/__tests__/authorization.test.ts
@@ -1,0 +1,171 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+import { ErrorCode } from '@/lib/api/errors';
+
+import { isAdmin, isManager, isManagerOf, isOwner, withRole } from '../authorization';
+import type { AuthenticatedRequest } from '../types';
+
+const { mockPrisma } = vi.hoisted(() => ({
+  mockPrisma: {
+    salesStaff: {
+      count: vi.fn(),
+      findUnique: vi.fn(),
+    },
+  },
+}));
+
+vi.mock('@/lib/prisma', () => ({
+  prisma: mockPrisma,
+}));
+
+describe('authorization', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('isAdmin', () => {
+    it.each([
+      { position: '課長', expected: true },
+      { position: '部長', expected: true },
+      { position: '本部長', expected: true },
+      { position: '役員', expected: true },
+      { position: '社長', expected: true },
+      { position: '主任', expected: false },
+      { position: '一般', expected: false },
+      { position: '', expected: false },
+    ])('position: "$position" => $expected', ({ position, expected }) => {
+      const user = { salesStaffId: 1, email: 'test@example.com', position };
+      expect(isAdmin(user)).toBe(expected);
+    });
+  });
+
+  describe('isManager', () => {
+    it('部下が存在する場合は true を返す', async () => {
+      mockPrisma.salesStaff.count.mockResolvedValue(3);
+      const result = await isManager(1);
+      expect(result).toBe(true);
+      expect(mockPrisma.salesStaff.count).toHaveBeenCalledWith({
+        where: { managerId: 1 },
+      });
+    });
+
+    it('部下が存在しない場合は false を返す', async () => {
+      mockPrisma.salesStaff.count.mockResolvedValue(0);
+      const result = await isManager(1);
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('isOwner', () => {
+    it('同一IDの場合は true を返す', () => {
+      expect(isOwner(1, 1)).toBe(true);
+    });
+
+    it('異なるIDの場合は false を返す', () => {
+      expect(isOwner(1, 2)).toBe(false);
+    });
+  });
+
+  describe('isManagerOf', () => {
+    it('指定ユーザーの上長である場合は true を返す', async () => {
+      mockPrisma.salesStaff.findUnique.mockResolvedValue({ managerId: 10 });
+      const result = await isManagerOf(10, 5);
+      expect(result).toBe(true);
+      expect(mockPrisma.salesStaff.findUnique).toHaveBeenCalledWith({
+        where: { id: 5 },
+        select: { managerId: true },
+      });
+    });
+
+    it('指定ユーザーの上長でない場合は false を返す', async () => {
+      mockPrisma.salesStaff.findUnique.mockResolvedValue({ managerId: 99 });
+      const result = await isManagerOf(10, 5);
+      expect(result).toBe(false);
+    });
+
+    it('指定ユーザーが存在しない場合は false を返す', async () => {
+      mockPrisma.salesStaff.findUnique.mockResolvedValue(null);
+      const result = await isManagerOf(10, 999);
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('withRole', () => {
+    function createAuthenticatedRequest(overrides: Partial<AuthenticatedRequest['auth']> = {}) {
+      return {
+        auth: {
+          salesStaffId: 1,
+          email: 'test@example.com',
+          position: '主任',
+          ...overrides,
+        },
+      } as AuthenticatedRequest;
+    }
+
+    const mockContext = { params: Promise.resolve({}) };
+    const mockHandler = vi.fn().mockResolvedValue(new Response('OK'));
+
+    beforeEach(() => {
+      mockHandler.mockClear();
+    });
+
+    it('authenticated ロールで認証済みユーザーを許可する', async () => {
+      const wrapped = withRole(['authenticated'], mockHandler);
+      const request = createAuthenticatedRequest();
+      await wrapped(request, mockContext);
+      expect(mockHandler).toHaveBeenCalledOnce();
+    });
+
+    it('admin ロールで管理者（課長）を許可する', async () => {
+      const wrapped = withRole(['admin'], mockHandler);
+      const request = createAuthenticatedRequest({ position: '課長' });
+      await wrapped(request, mockContext);
+      expect(mockHandler).toHaveBeenCalledOnce();
+    });
+
+    it('admin ロールで一般ユーザーを拒否する', async () => {
+      const wrapped = withRole(['admin'], mockHandler);
+      const request = createAuthenticatedRequest({ position: '一般' });
+      const response = await wrapped(request, mockContext);
+      expect(response.status).toBe(403);
+      const body = await response.json();
+      expect(body.error.code).toBe(ErrorCode.FORBIDDEN);
+      expect(mockHandler).not.toHaveBeenCalled();
+    });
+
+    it('manager ロールで部下を持つユーザーを許可する', async () => {
+      mockPrisma.salesStaff.count.mockResolvedValue(2);
+      const wrapped = withRole(['manager'], mockHandler);
+      const request = createAuthenticatedRequest();
+      await wrapped(request, mockContext);
+      expect(mockHandler).toHaveBeenCalledOnce();
+    });
+
+    it('manager ロールで部下を持たないユーザーを拒否する', async () => {
+      mockPrisma.salesStaff.count.mockResolvedValue(0);
+      const wrapped = withRole(['manager'], mockHandler);
+      const request = createAuthenticatedRequest();
+      const response = await wrapped(request, mockContext);
+      expect(response.status).toBe(403);
+      expect(mockHandler).not.toHaveBeenCalled();
+    });
+
+    it('複数ロール指定でいずれかに該当すれば許可する', async () => {
+      // admin でも manager でもないが、ここでは admin をチェック
+      const wrapped = withRole(['admin', 'manager'], mockHandler);
+      const request = createAuthenticatedRequest({ position: '部長' });
+      await wrapped(request, mockContext);
+      expect(mockHandler).toHaveBeenCalledOnce();
+      // admin で通ったので manager のDBチェックはスキップされる
+      expect(mockPrisma.salesStaff.count).not.toHaveBeenCalled();
+    });
+
+    it('admin は DB クエリを発行しない', async () => {
+      const wrapped = withRole(['admin'], mockHandler);
+      const request = createAuthenticatedRequest({ position: '課長' });
+      await wrapped(request, mockContext);
+      expect(mockPrisma.salesStaff.count).not.toHaveBeenCalled();
+      expect(mockPrisma.salesStaff.findUnique).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/app/src/lib/auth/__tests__/jwt.test.ts
+++ b/app/src/lib/auth/__tests__/jwt.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+import { ErrorCode } from '@/lib/api/errors';
+
+import { generateToken, verifyToken } from '../jwt';
+
+describe('jwt', () => {
+  beforeEach(() => {
+    vi.stubEnv('JWT_SECRET', 'test-secret-key-for-jwt-testing');
+  });
+
+  describe('generateToken', () => {
+    it('JWT トークンを生成できる', async () => {
+      const token = await generateToken({
+        sub: 1,
+        email: 'test@example.com',
+        position: '主任',
+      });
+      expect(token).toBeDefined();
+      expect(typeof token).toBe('string');
+      expect(token.split('.')).toHaveLength(3);
+    });
+
+    it('カスタム有効期限でトークンを生成できる', async () => {
+      const token = await generateToken(
+        { sub: 1, email: 'test@example.com', position: '主任' },
+        '1h',
+      );
+      expect(token).toBeDefined();
+    });
+  });
+
+  describe('verifyToken', () => {
+    it('生成したトークンを検証・デコードできる', async () => {
+      const payload = { sub: 42, email: 'user@example.com', position: '課長' };
+      const token = await generateToken(payload);
+      const decoded = await verifyToken(token);
+      expect(decoded.sub).toBe(42);
+      expect(decoded.email).toBe('user@example.com');
+      expect(decoded.position).toBe('課長');
+    });
+
+    it('JWT_SECRET が未設定の場合エラーをスローする', async () => {
+      vi.stubEnv('JWT_SECRET', '');
+      await expect(
+        generateToken({ sub: 1, email: 'test@example.com', position: '' }),
+      ).rejects.toThrow('JWT_SECRET 環境変数が設定されていません');
+    });
+
+    it('有効期限切れトークンで TOKEN_EXPIRED エラーをスローする', async () => {
+      const token = await generateToken(
+        { sub: 1, email: 'test@example.com', position: '主任' },
+        '0s',
+      );
+      // 少し待って有効期限を確実に過ぎさせる
+      await new Promise((resolve) => setTimeout(resolve, 1100));
+      try {
+        await verifyToken(token);
+        expect.fail('エラーがスローされるべき');
+      } catch (error: unknown) {
+        const appError = error as { code: string };
+        expect(appError.code).toBe(ErrorCode.TOKEN_EXPIRED);
+      }
+    });
+
+    it('不正なトークンで TOKEN_INVALID エラーをスローする', async () => {
+      try {
+        await verifyToken('invalid.token.string');
+        expect.fail('エラーがスローされるべき');
+      } catch (error: unknown) {
+        const appError = error as { code: string };
+        expect(appError.code).toBe(ErrorCode.TOKEN_INVALID);
+      }
+    });
+
+    it('異なる秘密鍵で署名されたトークンを拒否する', async () => {
+      const token = await generateToken({
+        sub: 1,
+        email: 'test@example.com',
+        position: '主任',
+      });
+      vi.stubEnv('JWT_SECRET', 'different-secret-key');
+      try {
+        await verifyToken(token);
+        expect.fail('エラーがスローされるべき');
+      } catch (error: unknown) {
+        const appError = error as { code: string };
+        expect(appError.code).toBe(ErrorCode.TOKEN_INVALID);
+      }
+    });
+
+    it('空文字列トークンで TOKEN_INVALID エラーをスローする', async () => {
+      try {
+        await verifyToken('');
+        expect.fail('エラーがスローされるべき');
+      } catch (error: unknown) {
+        const appError = error as { code: string };
+        expect(appError.code).toBe(ErrorCode.TOKEN_INVALID);
+      }
+    });
+
+    it('position が未設定の場合は空文字列をデフォルトとする', async () => {
+      // positionが空文字列のトークンを生成
+      const token = await generateToken({
+        sub: 1,
+        email: 'test@example.com',
+        position: '',
+      });
+      const decoded = await verifyToken(token);
+      expect(decoded.position).toBe('');
+    });
+  });
+});

--- a/app/src/lib/auth/__tests__/middleware.test.ts
+++ b/app/src/lib/auth/__tests__/middleware.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+
+import { ErrorCode } from '@/lib/api/errors';
+
+import { generateToken } from '../jwt';
+import { withAuth } from '../middleware';
+import type { AuthenticatedRequest } from '../types';
+
+describe('withAuth middleware', () => {
+  beforeEach(() => {
+    vi.stubEnv('JWT_SECRET', 'test-secret-key-for-middleware-testing');
+  });
+
+  function createRequest(headers: Record<string, string> = {}): NextRequest {
+    const req = new NextRequest('http://localhost:3000/api/v1/test', {
+      headers,
+    });
+    return req;
+  }
+
+  const mockContext = { params: Promise.resolve({}) };
+
+  it('有効なトークンで認証に成功し、ハンドラーを実行する', async () => {
+    const token = await generateToken({
+      sub: 1,
+      email: 'test@example.com',
+      position: '主任',
+    });
+
+    const handler = vi.fn().mockResolvedValue(new Response('OK'));
+    const wrapped = withAuth(handler);
+
+    const request = createRequest({ Authorization: `Bearer ${token}` });
+    const response = await wrapped(request, mockContext);
+
+    expect(response).toBeDefined();
+    expect(handler).toHaveBeenCalledOnce();
+
+    // ハンドラーに渡されたリクエストにauth情報が含まれることを確認
+    const calledRequest = handler.mock.calls[0][0] as AuthenticatedRequest;
+    expect(calledRequest.auth).toBeDefined();
+    expect(calledRequest.auth.salesStaffId).toBe(1);
+    expect(calledRequest.auth.email).toBe('test@example.com');
+    expect(calledRequest.auth.position).toBe('主任');
+  });
+
+  it('Authorization ヘッダーがない場合は 401 を返す', async () => {
+    const handler = vi.fn();
+    const wrapped = withAuth(handler);
+
+    const request = createRequest();
+    const response = await wrapped(request, mockContext);
+
+    expect(response.status).toBe(401);
+    const body = await response.json();
+    expect(body.error.code).toBe(ErrorCode.TOKEN_INVALID);
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it('Bearer 以外のスキームの場合は 401 を返す', async () => {
+    const handler = vi.fn();
+    const wrapped = withAuth(handler);
+
+    const request = createRequest({ Authorization: 'Basic abc123' });
+    const response = await wrapped(request, mockContext);
+
+    expect(response.status).toBe(401);
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it('不正なトークンの場合は 401 を返す', async () => {
+    const handler = vi.fn();
+    const wrapped = withAuth(handler);
+
+    const request = createRequest({ Authorization: 'Bearer invalid-token' });
+    const response = await wrapped(request, mockContext);
+
+    expect(response.status).toBe(401);
+    const body = await response.json();
+    expect(body.error.code).toBe(ErrorCode.TOKEN_INVALID);
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it('有効期限切れトークンの場合は 401 を返す', async () => {
+    const token = await generateToken(
+      { sub: 1, email: 'test@example.com', position: '主任' },
+      '0s',
+    );
+    await new Promise((resolve) => setTimeout(resolve, 1100));
+
+    const handler = vi.fn();
+    const wrapped = withAuth(handler);
+
+    const request = createRequest({ Authorization: `Bearer ${token}` });
+    const response = await wrapped(request, mockContext);
+
+    expect(response.status).toBe(401);
+    const body = await response.json();
+    expect(body.error.code).toBe(ErrorCode.TOKEN_EXPIRED);
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it('Bearer トークンが空文字の場合は 401 を返す', async () => {
+    const handler = vi.fn();
+    const wrapped = withAuth(handler);
+
+    const request = createRequest({ Authorization: 'Bearer ' });
+    const response = await wrapped(request, mockContext);
+
+    expect(response.status).toBe(401);
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it('"Bearer" のみ（スペースなし）の場合は 401 を返す', async () => {
+    const handler = vi.fn();
+    const wrapped = withAuth(handler);
+
+    const request = createRequest({ Authorization: 'Bearer' });
+    const response = await wrapped(request, mockContext);
+
+    expect(response.status).toBe(401);
+    expect(handler).not.toHaveBeenCalled();
+  });
+});

--- a/app/src/lib/auth/__tests__/password.test.ts
+++ b/app/src/lib/auth/__tests__/password.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+
+import { hashPassword, verifyPassword } from '../password';
+
+describe('password', () => {
+  describe('hashPassword', () => {
+    it('平文パスワードをハッシュ化できる', async () => {
+      const plainPassword = 'password123';
+      const hashed = await hashPassword(plainPassword);
+      expect(hashed).toBeDefined();
+      expect(hashed).not.toBe(plainPassword);
+      expect(hashed).toMatch(/^\$2[ab]\$/);
+    });
+
+    it('同じパスワードでも毎回異なるハッシュを生成する', async () => {
+      const plainPassword = 'password123';
+      const hash1 = await hashPassword(plainPassword);
+      const hash2 = await hashPassword(plainPassword);
+      expect(hash1).not.toBe(hash2);
+    });
+
+    it('空文字列でもハッシュ化できる', async () => {
+      const hashed = await hashPassword('');
+      expect(hashed).toBeDefined();
+      expect(hashed).toMatch(/^\$2[ab]\$/);
+    });
+  });
+
+  describe('verifyPassword', () => {
+    it('正しいパスワードで検証が成功する', async () => {
+      const plainPassword = 'securePass123';
+      const hashed = await hashPassword(plainPassword);
+      const result = await verifyPassword(plainPassword, hashed);
+      expect(result).toBe(true);
+    });
+
+    it('間違ったパスワードで検証が失敗する', async () => {
+      const plainPassword = 'securePass123';
+      const hashed = await hashPassword(plainPassword);
+      const result = await verifyPassword('wrongPassword', hashed);
+      expect(result).toBe(false);
+    });
+
+    it('日本語を含むパスワードでもハッシュ化・検証できる', async () => {
+      const plainPassword = 'パスワード123';
+      const hashed = await hashPassword(plainPassword);
+      expect(await verifyPassword(plainPassword, hashed)).toBe(true);
+      expect(await verifyPassword('wrong', hashed)).toBe(false);
+    });
+
+    it('長いパスワードでもハッシュ化・検証できる', async () => {
+      const plainPassword = 'a'.repeat(100);
+      const hashed = await hashPassword(plainPassword);
+      expect(await verifyPassword(plainPassword, hashed)).toBe(true);
+    });
+  });
+});

--- a/app/src/lib/auth/authorization.ts
+++ b/app/src/lib/auth/authorization.ts
@@ -1,0 +1,91 @@
+import { AppError, ErrorCode } from '@/lib/api/errors';
+import { createErrorResponse } from '@/lib/api/response';
+import { prisma } from '@/lib/prisma';
+
+import type { AuthenticatedRequest, AuthenticatedRouteHandler, AuthUser } from './types';
+
+/**
+ * 管理者（admin）判定に使用する役職リスト
+ * 「課長」以上の役職を管理者とする
+ */
+const ADMIN_POSITIONS = ['課長', '部長', '本部長', '役員', '社長'];
+
+/**
+ * ユーザーが管理者（admin）かどうかを判定する
+ */
+export function isAdmin(user: AuthUser): boolean {
+  return ADMIN_POSITIONS.includes(user.position);
+}
+
+/**
+ * ユーザーが上長（manager）かどうかをDBで判定する
+ */
+export async function isManager(userId: number): Promise<boolean> {
+  const subordinateCount = await prisma.salesStaff.count({
+    where: {
+      managerId: userId,
+    },
+  });
+  return subordinateCount > 0;
+}
+
+/**
+ * ユーザーがリソースの所有者（owner）かどうかを判定する
+ */
+export function isOwner(userId: number, resourceOwnerId: number): boolean {
+  return userId === resourceOwnerId;
+}
+
+/**
+ * 指定したユーザーが、特定ユーザーの上長であるかをDBで判定する
+ */
+export async function isManagerOf(managerId: number, staffId: number): Promise<boolean> {
+  const staff = await prisma.salesStaff.findUnique({
+    where: { id: staffId },
+    select: { managerId: true },
+  });
+  return staff?.managerId === managerId;
+}
+
+/** 権限チェックで使用するロール種別 */
+export type Role = 'admin' | 'manager' | 'authenticated';
+
+/**
+ * 権限チェックミドルウェア
+ */
+export function withRole(roles: Role[], handler: AuthenticatedRouteHandler) {
+  return async (
+    request: AuthenticatedRequest,
+    context: { params: Promise<Record<string, string>> },
+  ): Promise<Response> => {
+    const user = request.auth;
+
+    if (roles.includes('authenticated')) {
+      return handler(request, context);
+    }
+
+    let hasPermission = false;
+
+    for (const role of roles) {
+      switch (role) {
+        case 'admin':
+          if (isAdmin(user)) {
+            hasPermission = true;
+          }
+          break;
+        case 'manager':
+          if (await isManager(user.salesStaffId)) {
+            hasPermission = true;
+          }
+          break;
+      }
+      if (hasPermission) break;
+    }
+
+    if (!hasPermission) {
+      return createErrorResponse(new AppError(ErrorCode.FORBIDDEN, '権限が不足しています'));
+    }
+
+    return handler(request, context);
+  };
+}

--- a/app/src/lib/auth/index.ts
+++ b/app/src/lib/auth/index.ts
@@ -1,0 +1,23 @@
+// 認証基盤のパブリックAPI
+
+// JWT
+export { generateToken, verifyToken } from './jwt';
+export type { JwtPayload } from './jwt';
+
+// パスワード
+export { hashPassword, verifyPassword } from './password';
+
+// ミドルウェア
+export { withAuth } from './middleware';
+
+// 権限チェック
+export { isAdmin, isManager, isManagerOf, isOwner, withRole } from './authorization';
+export type { Role } from './authorization';
+
+// 型定義
+export type {
+  AuthenticatedRequest,
+  AuthenticatedRouteHandler,
+  AuthUser,
+  RouteHandler,
+} from './types';

--- a/app/src/lib/auth/jwt.ts
+++ b/app/src/lib/auth/jwt.ts
@@ -1,0 +1,80 @@
+import { jwtVerify, SignJWT } from 'jose';
+
+import { AppError, ErrorCode } from '@/lib/api/errors';
+
+/** JWT ペイロードの型定義 */
+export interface JwtPayload {
+  /** ユーザーID (subject) */
+  sub: number;
+  /** メールアドレス */
+  email: string;
+  /** 役職 */
+  position: string;
+}
+
+/** デフォルトの有効期限（24時間） */
+const DEFAULT_EXPIRATION = '24h';
+
+/**
+ * JWT_SECRET 環境変数から署名キーを取得する
+ */
+function getSecretKey(): Uint8Array {
+  const secret = process.env.JWT_SECRET;
+  if (!secret) {
+    throw new Error('JWT_SECRET 環境変数が設定されていません');
+  }
+  return new TextEncoder().encode(secret);
+}
+
+/**
+ * JWT トークンを生成する
+ */
+export async function generateToken(
+  payload: JwtPayload,
+  expiresIn: string = DEFAULT_EXPIRATION,
+): Promise<string> {
+  const secretKey = getSecretKey();
+
+  const token = await new SignJWT({
+    email: payload.email,
+    position: payload.position,
+  })
+    .setProtectedHeader({ alg: 'HS256' })
+    .setSubject(String(payload.sub))
+    .setIssuedAt()
+    .setExpirationTime(expiresIn)
+    .sign(secretKey);
+
+  return token;
+}
+
+/**
+ * JWT トークンを検証・デコードする
+ */
+export async function verifyToken(token: string): Promise<JwtPayload> {
+  const secretKey = getSecretKey();
+
+  try {
+    const { payload } = await jwtVerify(token, secretKey);
+
+    if (!payload.sub || !payload.email) {
+      throw new AppError(ErrorCode.TOKEN_INVALID, '不正なトークンです');
+    }
+
+    return {
+      sub: parseInt(payload.sub, 10),
+      email: payload.email as string,
+      position: (payload.position as string) || '',
+    };
+  } catch (error) {
+    if (error instanceof AppError) {
+      throw error;
+    }
+
+    if (error instanceof Error && error.name === 'JWTExpired') {
+      throw new AppError(ErrorCode.TOKEN_EXPIRED, 'トークンの有効期限が切れています');
+    }
+
+    throw new AppError(ErrorCode.TOKEN_INVALID, '不正なトークンです');
+  }
+}

--- a/app/src/lib/auth/middleware.ts
+++ b/app/src/lib/auth/middleware.ts
@@ -1,0 +1,71 @@
+import type { NextRequest } from 'next/server';
+
+import { AppError, ErrorCode } from '@/lib/api/errors';
+import { createErrorResponse } from '@/lib/api/response';
+
+import { verifyToken } from './jwt';
+import type { AuthenticatedRequest, AuthenticatedRouteHandler, AuthUser } from './types';
+
+/**
+ * Authorization ヘッダーから Bearer トークンを抽出する
+ */
+function extractBearerToken(request: NextRequest): string | null {
+  const authorization = request.headers.get('Authorization');
+  if (!authorization) {
+    return null;
+  }
+
+  const parts = authorization.split(' ');
+  if (parts.length !== 2 || parts[0] !== 'Bearer') {
+    return null;
+  }
+
+  return parts[1];
+}
+
+/**
+ * 認証ミドルウェア
+ *
+ * ルートハンドラーをラップし、JWT トークンの検証を行う。
+ * 検証に成功した場合、request.auth に認証ユーザー情報を設定してハンドラーを実行する。
+ * 検証に失敗した場合、401 エラーレスポンスを返す。
+ */
+export function withAuth(handler: AuthenticatedRouteHandler) {
+  return async (
+    request: NextRequest,
+    context: { params: Promise<Record<string, string>> },
+  ): Promise<Response> => {
+    const token = extractBearerToken(request);
+
+    if (!token) {
+      return createErrorResponse(new AppError(ErrorCode.TOKEN_INVALID, '認証トークンが必要です'));
+    }
+
+    try {
+      const payload = await verifyToken(token);
+
+      const authUser: AuthUser = {
+        salesStaffId: payload.sub,
+        email: payload.email,
+        position: payload.position,
+      };
+
+      const authenticatedRequest = request as AuthenticatedRequest;
+      Object.defineProperty(authenticatedRequest, 'auth', {
+        value: authUser,
+        writable: false,
+        enumerable: true,
+      });
+
+      return handler(authenticatedRequest, context);
+    } catch (error) {
+      if (error instanceof AppError) {
+        return createErrorResponse(error);
+      }
+
+      return createErrorResponse(
+        new AppError(ErrorCode.INTERNAL_ERROR, 'サーバー内部エラーが発生しました'),
+      );
+    }
+  };
+}

--- a/app/src/lib/auth/password.ts
+++ b/app/src/lib/auth/password.ts
@@ -1,0 +1,22 @@
+import bcrypt from 'bcryptjs';
+
+/** bcrypt のソルトラウンド数 */
+const SALT_ROUNDS = 12;
+
+/**
+ * パスワードをハッシュ化する
+ */
+export async function hashPassword(plainPassword: string): Promise<string> {
+  return bcrypt.hash(plainPassword, SALT_ROUNDS);
+}
+
+/**
+ * パスワードを検証する
+ * @returns 一致する場合は true
+ */
+export async function verifyPassword(
+  plainPassword: string,
+  hashedPassword: string,
+): Promise<boolean> {
+  return bcrypt.compare(plainPassword, hashedPassword);
+}

--- a/app/src/lib/auth/types.ts
+++ b/app/src/lib/auth/types.ts
@@ -1,0 +1,36 @@
+import type { NextRequest } from 'next/server';
+
+/**
+ * 認証済みユーザーのコンテキスト情報
+ */
+export interface AuthUser {
+  /** 営業担当者ID */
+  salesStaffId: number;
+  /** メールアドレス */
+  email: string;
+  /** 役職 */
+  position: string;
+}
+
+/**
+ * 認証情報付きリクエスト
+ */
+export interface AuthenticatedRequest extends NextRequest {
+  auth: AuthUser;
+}
+
+/**
+ * 認証済みルートハンドラーの型定義
+ */
+export type AuthenticatedRouteHandler = (
+  request: AuthenticatedRequest,
+  context: { params: Promise<Record<string, string>> },
+) => Promise<Response>;
+
+/**
+ * 通常のルートハンドラーの型定義
+ */
+export type RouteHandler = (
+  request: NextRequest,
+  context: { params: Promise<Record<string, string>> },
+) => Promise<Response>;

--- a/app/src/lib/utils/date.ts
+++ b/app/src/lib/utils/date.ts
@@ -1,0 +1,46 @@
+/**
+ * Date オブジェクトを YYYY-MM-DD 形式の文字列に変換する
+ */
+export function formatDate(date: Date): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+/**
+ * Date オブジェクトを ISO 8601 形式（タイムゾーン付き）の文字列に変換する
+ * 例: 2026-03-02T18:30:00+09:00
+ */
+export function formatDateTime(date: Date): string {
+  return date.toISOString();
+}
+
+/**
+ * YYYY-MM-DD 形式の文字列を Date オブジェクトに変換する
+ * 無効な日付の場合は null を返す
+ */
+export function parseDate(dateString: string): Date | null {
+  const match = dateString.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+  if (!match) return null;
+
+  const [, yearStr, monthStr, dayStr] = match;
+  const year = parseInt(yearStr, 10);
+  const month = parseInt(monthStr, 10);
+  const day = parseInt(dayStr, 10);
+
+  const date = new Date(year, month - 1, day);
+
+  if (date.getFullYear() !== year || date.getMonth() !== month - 1 || date.getDate() !== day) {
+    return null;
+  }
+
+  return date;
+}
+
+/**
+ * 今日の日付を YYYY-MM-DD 形式で取得する
+ */
+export function today(): string {
+  return formatDate(new Date());
+}

--- a/app/src/lib/validations/auth.ts
+++ b/app/src/lib/validations/auth.ts
@@ -1,0 +1,15 @@
+import { z } from 'zod';
+
+/**
+ * ログインリクエストのバリデーションスキーマ
+ */
+export const loginSchema = z.object({
+  email: z
+    .string({ error: 'メールアドレスを入力してください' })
+    .email('メールアドレスの形式が正しくありません'),
+  password: z
+    .string({ error: 'パスワードを入力してください' })
+    .min(1, 'パスワードを入力してください'),
+});
+
+export type LoginInput = z.infer<typeof loginSchema>;

--- a/app/src/lib/validations/comment.ts
+++ b/app/src/lib/validations/comment.ts
@@ -1,0 +1,13 @@
+import { z } from 'zod';
+
+/**
+ * コメント投稿リクエストのバリデーションスキーマ
+ */
+export const commentCreateSchema = z.object({
+  comment_body: z
+    .string({ error: 'コメントを入力してください' })
+    .min(1, 'コメントを入力してください')
+    .max(1000, 'コメントは1000文字以内で入力してください'),
+});
+
+export type CommentCreateInput = z.infer<typeof commentCreateSchema>;

--- a/app/src/lib/validations/common.ts
+++ b/app/src/lib/validations/common.ts
@@ -1,0 +1,23 @@
+import { z } from 'zod';
+
+/**
+ * YYYY-MM-DD 形式の日付文字列バリデーション
+ */
+export const dateStringSchema = z
+  .string({ error: '日付を入力してください' })
+  .regex(/^\d{4}-\d{2}-\d{2}$/, '日付はYYYY-MM-DD形式で入力してください')
+  .refine(
+    (val) => {
+      const date = new Date(val);
+      return !isNaN(date.getTime());
+    },
+    { message: '有効な日付を入力してください' },
+  );
+
+/**
+ * 正の整数IDバリデーション（パスパラメータ用）
+ */
+export const idParamSchema = z.coerce
+  .number({ error: 'IDは正の整数で指定してください' })
+  .int('IDは整数で指定してください')
+  .positive('IDは正の整数で指定してください');

--- a/app/src/lib/validations/customer.ts
+++ b/app/src/lib/validations/customer.ts
@@ -1,0 +1,41 @@
+import { z } from 'zod';
+
+/**
+ * 顧客登録リクエストのバリデーションスキーマ
+ */
+export const customerCreateSchema = z.object({
+  customer_name: z
+    .string({ error: '顧客名を入力してください' })
+    .min(1, '顧客名を入力してください')
+    .max(200, '顧客名は200文字以内で入力してください'),
+  address: z.string().max(500, '住所は500文字以内で入力してください').optional(),
+  phone: z.string().optional(),
+  sales_staff_id: z.number().int().positive().optional(),
+});
+
+/**
+ * 顧客更新リクエストのバリデーションスキーマ
+ */
+export const customerUpdateSchema = z.object({
+  customer_name: z
+    .string({ error: '顧客名を入力してください' })
+    .min(1, '顧客名を入力してください')
+    .max(200, '顧客名は200文字以内で入力してください'),
+  address: z.string().max(500, '住所は500文字以内で入力してください').optional(),
+  phone: z.string().optional(),
+  sales_staff_id: z.number().int().positive().optional(),
+});
+
+/**
+ * 顧客一覧検索パラメータのバリデーションスキーマ
+ */
+export const customerSearchSchema = z.object({
+  customer_name: z.string().optional(),
+  sales_staff_id: z.coerce.number().int().positive().optional(),
+  page: z.coerce.number().int().min(1).optional(),
+  per_page: z.coerce.number().int().min(1).max(100).optional(),
+});
+
+export type CustomerCreateInput = z.infer<typeof customerCreateSchema>;
+export type CustomerUpdateInput = z.infer<typeof customerUpdateSchema>;
+export type CustomerSearchInput = z.infer<typeof customerSearchSchema>;

--- a/app/src/lib/validations/index.ts
+++ b/app/src/lib/validations/index.ts
@@ -1,0 +1,34 @@
+export { loginSchema, type LoginInput } from './auth';
+export { dateStringSchema, idParamSchema } from './common';
+export { commentCreateSchema, type CommentCreateInput } from './comment';
+export {
+  customerCreateSchema,
+  customerSearchSchema,
+  customerUpdateSchema,
+  type CustomerCreateInput,
+  type CustomerSearchInput,
+  type CustomerUpdateInput,
+} from './customer';
+export {
+  reportCreateSchema,
+  reportSearchSchema,
+  reportStatusSchema,
+  reportUpdateSchema,
+  type ReportCreateInput,
+  type ReportSearchInput,
+  type ReportUpdateInput,
+} from './report';
+export {
+  staffCreateSchema,
+  staffSearchSchema,
+  staffUpdateSchema,
+  type StaffCreateInput,
+  type StaffSearchInput,
+  type StaffUpdateInput,
+} from './staff';
+export {
+  visitCreateSchema,
+  visitUpdateSchema,
+  type VisitCreateInput,
+  type VisitUpdateInput,
+} from './visit';

--- a/app/src/lib/validations/report.ts
+++ b/app/src/lib/validations/report.ts
@@ -1,0 +1,89 @@
+import { z } from 'zod';
+
+import { dateStringSchema } from './common';
+
+/**
+ * 訪問記録のバリデーションスキーマ（日報内ネスト用）
+ */
+const visitRecordInputSchema = z.object({
+  customer_id: z
+    .number({ error: '顧客IDを入力してください' })
+    .int('顧客IDは整数で入力してください')
+    .positive('顧客IDは正の整数で入力してください'),
+  visit_content: z
+    .string({ error: '訪問内容を入力してください' })
+    .min(1, '訪問内容を入力してください')
+    .max(2000, '訪問内容は2000文字以内で入力してください'),
+});
+
+/**
+ * 日報ステータス
+ */
+export const reportStatusSchema = z.enum(['draft', 'submitted'], {
+  error: 'ステータスは draft または submitted を指定してください',
+});
+
+/**
+ * 日報作成リクエストのバリデーションスキーマ
+ */
+export const reportCreateSchema = z
+  .object({
+    report_date: dateStringSchema,
+    status: reportStatusSchema,
+    problem: z.string().max(2000, '課題・相談は2000文字以内で入力してください').optional(),
+    plan: z.string().max(2000, '明日やることは2000文字以内で入力してください').optional(),
+    visit_records: z.array(visitRecordInputSchema).optional(),
+  })
+  .refine(
+    (data) => {
+      if (data.status === 'submitted') {
+        return data.visit_records && data.visit_records.length > 0;
+      }
+      return true;
+    },
+    {
+      message: '提出時は訪問記録を1件以上入力してください',
+      path: ['visit_records'],
+    },
+  );
+
+/**
+ * 日報更新リクエストのバリデーションスキーマ
+ */
+export const reportUpdateSchema = z
+  .object({
+    report_date: dateStringSchema,
+    status: reportStatusSchema,
+    problem: z.string().max(2000, '課題・相談は2000文字以内で入力してください').optional(),
+    plan: z.string().max(2000, '明日やることは2000文字以内で入力してください').optional(),
+    visit_records: z.array(visitRecordInputSchema).optional(),
+  })
+  .refine(
+    (data) => {
+      if (data.status === 'submitted') {
+        return data.visit_records && data.visit_records.length > 0;
+      }
+      return true;
+    },
+    {
+      message: '提出時は訪問記録を1件以上入力してください',
+      path: ['visit_records'],
+    },
+  );
+
+/**
+ * 日報一覧検索パラメータのバリデーションスキーマ
+ */
+export const reportSearchSchema = z.object({
+  date_from: dateStringSchema.optional(),
+  date_to: dateStringSchema.optional(),
+  sales_staff_id: z.coerce.number().int().positive().optional(),
+  customer_name: z.string().optional(),
+  status: z.enum(['draft', 'submitted', 'commented']).optional(),
+  page: z.coerce.number().int().min(1).optional(),
+  per_page: z.coerce.number().int().min(1).max(100).optional(),
+});
+
+export type ReportCreateInput = z.infer<typeof reportCreateSchema>;
+export type ReportUpdateInput = z.infer<typeof reportUpdateSchema>;
+export type ReportSearchInput = z.infer<typeof reportSearchSchema>;

--- a/app/src/lib/validations/staff.ts
+++ b/app/src/lib/validations/staff.ts
@@ -1,0 +1,55 @@
+import { z } from 'zod';
+
+/**
+ * 営業担当者登録リクエストのバリデーションスキーマ
+ */
+export const staffCreateSchema = z.object({
+  name: z
+    .string({ error: '氏名を入力してください' })
+    .min(1, '氏名を入力してください')
+    .max(100, '氏名は100文字以内で入力してください'),
+  email: z
+    .string({ error: 'メールアドレスを入力してください' })
+    .email('メールアドレスの形式が正しくありません'),
+  password: z
+    .string({ error: 'パスワードを入力してください' })
+    .min(8, 'パスワードは8文字以上で入力してください'),
+  department: z.string().max(100, '部署は100文字以内で入力してください').optional(),
+  position: z.string().max(50, '役職は50文字以内で入力してください').optional(),
+  manager_id: z.number().int().positive().optional().nullable(),
+});
+
+/**
+ * 営業担当者更新リクエストのバリデーションスキーマ
+ */
+export const staffUpdateSchema = z.object({
+  name: z
+    .string({ error: '氏名を入力してください' })
+    .min(1, '氏名を入力してください')
+    .max(100, '氏名は100文字以内で入力してください'),
+  email: z
+    .string({ error: 'メールアドレスを入力してください' })
+    .email('メールアドレスの形式が正しくありません'),
+  password: z.string().optional(),
+  department: z.string().max(100, '部署は100文字以内で入力してください').optional(),
+  position: z.string().max(50, '役職は50文字以内で入力してください').optional(),
+  manager_id: z.number().int().positive().optional().nullable(),
+});
+
+/**
+ * 営業一覧検索パラメータのバリデーションスキーマ
+ */
+export const staffSearchSchema = z.object({
+  name: z.string().optional(),
+  department: z.string().optional(),
+  simple: z
+    .string()
+    .transform((val) => val === 'true')
+    .optional(),
+  page: z.coerce.number().int().min(1).optional(),
+  per_page: z.coerce.number().int().min(1).max(100).optional(),
+});
+
+export type StaffCreateInput = z.infer<typeof staffCreateSchema>;
+export type StaffUpdateInput = z.infer<typeof staffUpdateSchema>;
+export type StaffSearchInput = z.infer<typeof staffSearchSchema>;

--- a/app/src/lib/validations/visit.ts
+++ b/app/src/lib/validations/visit.ts
@@ -1,0 +1,32 @@
+import { z } from 'zod';
+
+/**
+ * 訪問記録作成リクエストのバリデーションスキーマ
+ */
+export const visitCreateSchema = z.object({
+  customer_id: z
+    .number({ error: '顧客IDを入力してください' })
+    .int('顧客IDは整数で入力してください')
+    .positive('顧客IDは正の整数で入力してください'),
+  visit_content: z
+    .string({ error: '訪問内容を入力してください' })
+    .min(1, '訪問内容を入力してください')
+    .max(2000, '訪問内容は2000文字以内で入力してください'),
+});
+
+/**
+ * 訪問記録更新リクエストのバリデーションスキーマ
+ */
+export const visitUpdateSchema = z.object({
+  customer_id: z
+    .number({ error: '顧客IDを入力してください' })
+    .int('顧客IDは整数で入力してください')
+    .positive('顧客IDは正の整数で入力してください'),
+  visit_content: z
+    .string({ error: '訪問内容を入力してください' })
+    .min(1, '訪問内容を入力してください')
+    .max(2000, '訪問内容は2000文字以内で入力してください'),
+});
+
+export type VisitCreateInput = z.infer<typeof visitCreateSchema>;
+export type VisitUpdateInput = z.infer<typeof visitUpdateSchema>;

--- a/app/vitest.config.ts
+++ b/app/vitest.config.ts
@@ -1,0 +1,20 @@
+import path from 'path';
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+    coverage: {
+      provider: 'v8',
+      include: ['src/lib/**/*.ts'],
+      exclude: ['src/lib/**/index.ts', 'src/generated/**'],
+    },
+  },
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, 'src'),
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- JWT認証基盤（トークン生成・検証、パスワードハッシュ化、認証ミドルウェア、権限チェック）を実装
- API共通基盤（レスポンスヘルパー、エラーハンドリング、バリデーションスキーマ、ハンドラーラッパー）を実装
- 全86件のユニットテストを追加（全件パス）

## Changes
### 認証モジュール (`app/src/lib/auth/`)
- `jwt.ts` - jose を使用した JWT 生成・検証（HS256、有効期限設定可能）
- `password.ts` - bcryptjs によるパスワードハッシュ化・検証
- `middleware.ts` - `withAuth` Bearer Token 認証ミドルウェア
- `authorization.ts` - `isAdmin`, `isManager`, `isOwner`, `withRole` 権限チェック
- `types.ts` - AuthUser, AuthenticatedRequest 型定義

### API共通基盤 (`app/src/lib/api/`)
- `errors.ts` - API仕様書準拠のエラーコード・AppError クラス
- `handler.ts` - API ハンドラーラッパー（エラーハンドリング統合）
- `response.ts` - 統一レスポンスヘルパー

### バリデーション (`app/src/lib/validations/`)
- Zod スキーマ（auth, report, visit, comment, customer, staff, common）

### テスト (86件)
- password (7), jwt (9), middleware (7), authorization (22), errors (16), response (25)

## Test plan
- [x] `npm test` で全86テストがパス
- [x] ESLint エラーなし
- [ ] 後続の API エンドポイント実装で結合テスト

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)